### PR TITLE
Update reset password functionality and enhance axios configuration

### DIFF
--- a/src/app/(auth)/reset-password.tsx
+++ b/src/app/(auth)/reset-password.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { IResetPasswordFormDataRequest, ResetPasswordFormDataRequest } from '@models/user/user.request';
 import { ROUTES } from '@routes/routes';
 import authService from '@services/auth';
+import { useEmailSelector } from '@stores/user/user.selectors';
 import { router } from 'expo-router';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -21,6 +22,7 @@ export default function ResetPasswordScreen() {
      */
     const { t } = useTranslation();
     const { toast } = useToast();
+    const email = useEmailSelector();
     z.setErrorMap(makeZodI18nMap({ t }));
     //-----------------------End-----------------------//
 
@@ -36,7 +38,7 @@ export default function ResetPasswordScreen() {
     } = useForm<IResetPasswordFormDataRequest>({
         resolver: zodResolver(ResetPasswordFormDataRequest),
         defaultValues: {
-            email: '',
+            email: email,
             newPassword: '',
             confirmNewPassword: ''
         },
@@ -47,7 +49,7 @@ export default function ResetPasswordScreen() {
         try {
             const res = await authService.resetPassword(data);
 
-            if (res.data.statusCode === 200) {
+            if (res.data.statusCode === 201) {
                 toast({ variant: 'Success', description: res.data.message });
                 router.replace(ROUTES.AUTH.PASSWORD);
             }

--- a/src/configs/axios.ts
+++ b/src/configs/axios.ts
@@ -1,13 +1,17 @@
 import * as SecureStore from 'expo-secure-store';
 
 import { ROUTES } from '@routes/routes';
+import { useLanguageSelector } from '@stores/global/global.selectors';
 import axios, { AxiosError } from 'axios';
 import { router } from 'expo-router';
+
+const locale = useLanguageSelector();
 
 const axiosClient = axios.create({
     baseURL: process.env.EXPO_PUBLIC_API_URL,
     headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': locale,
     },
 });
 
@@ -15,6 +19,7 @@ const axiosPrivate = axios.create({
     baseURL: process.env.EXPO_PUBLIC_API_URL,
     headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': locale,
     },
     withCredentials: true,
 });

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,28 +1,26 @@
-import * as Localization from 'expo-localization';
+// src/configs/i18n.ts (hoặc một đường dẫn tương tự)
+
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import { useLanguageSelector } from '@stores/global/global.selectors';
 import en from './en.json';
 import vi from './vi.json';
 
-const resources = {
+export const resources = {
     en: { translation: en },
     vi: { translation: vi },
 };
-
-const language = useLanguageSelector();
-const locale = Localization.getLocales()[0]?.languageCode || language;
 
 i18n
     .use(initReactI18next)
     .init({
         resources,
-        lng: locale && resources[locale as keyof typeof resources] ? locale : 'en',
+        lng: 'en',
         fallbackLng: 'en',
         interpolation: {
             escapeValue: false,
         },
+        compatibilityJSON: 'v4',
     });
 
 export default i18n;


### PR DESCRIPTION
- Integrated email selector in ResetPasswordScreen to pre-fill email field for user convenience.
- Adjusted response handling in reset password service to correctly check for status code 201.
- Updated axios configuration to include 'Accept-Language' header based on user language selection, improving localization support.
- Refactored i18n initialization to set default language to 'en', ensuring consistent language handling across the application.