### PR TITLE
fix: ensure wallet-user query is invalidated after successful quiz re…

### DIFF
--- a/src/app/(app)/quiz/index.tsx
+++ b/src/app/(app)/quiz/index.tsx
@@ -374,8 +374,8 @@ export default function QuizScreen() {
       {
         onSuccess: (response) => {
           // Navigate to result screen with response data
+          queryClient.invalidateQueries({ queryKey: ["wallet-user"] });
           if (response.data) {
-            queryClient.invalidateQueries({ queryKey: ["wallet-user"] });
             // Pass data as JSON string in params
             router.replace({
               pathname: ROUTES.QUIZ.RESULT,


### PR DESCRIPTION
…sponse

- Updated QuizScreen to call queryClient.invalidateQueries for wallet-user after receiving a successful response, ensuring the latest user data is fetched.