### PR TITLE
feat: clear notification cache and toast on logout

### DIFF
--- a/src/app/(app)/(me)/settings.tsx
+++ b/src/app/(app)/(me)/settings.tsx
@@ -3,6 +3,8 @@ import BackScreen from "@components/molecules/Back";
 import BounceButton from "@components/ui/BounceButton";
 import { ROUTES } from "@routes/routes";
 import { useAuthStore } from "@stores/auth/auth.config";
+import { useNotificationToastStore } from "@stores/notification/notification-ui.store";
+import { useQueryClient } from "@tanstack/react-query";
 import { router } from "expo-router";
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -12,6 +14,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 export default function SettingsScreen() {
   const { t } = useTranslation();
   const { deleteAccessToken } = useAuthStore();
+  const queryClient = useQueryClient();
+  const { hideToast } = useNotificationToastStore();
 
   return (
     <SafeAreaView className="flex-1 bg-slate-50">
@@ -40,6 +44,9 @@ export default function SettingsScreen() {
                 {
                   text: t("settings.logout"),
                   onPress: () => {
+                    // Clear notification cache and toast before logout to prevent showing old notifications
+                    queryClient.removeQueries({ queryKey: ['notification'] });
+                    hideToast();
                     deleteAccessToken();
                     router.replace(ROUTES.AUTH.WELCOME);
                   },

--- a/src/configs/axios.ts
+++ b/src/configs/axios.ts
@@ -1,7 +1,9 @@
 import * as SecureStore from 'expo-secure-store';
 
 import { ROUTES } from '@routes/routes';
+import { queryClient } from '@libs/@tanstack/react-query';
 import { useAuthStore } from '@stores/auth/auth.config';
+import { useNotificationToastStore } from '@stores/notification/notification-ui.store';
 import { useGlobalStore } from '@stores/global/global.config';
 import axios, { AxiosError } from 'axios';
 import { router } from 'expo-router';
@@ -134,6 +136,9 @@ axiosPrivate.interceptors.response.use(
             }
 
             // Refresh failed -> force logout
+            // Clear notification cache and toast before logout to prevent showing old notifications
+            queryClient.removeQueries({ queryKey: ['notification'] });
+            useNotificationToastStore.getState().hideToast();
             await SecureStore.deleteItemAsync('accessToken');
             await SecureStore.deleteItemAsync('refreshToken');
             useAuthStore.getState().deleteAccessToken();

--- a/src/libs/@tanstack/react-query.tsx
+++ b/src/libs/@tanstack/react-query.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Platform } from 'react-native';
 
 // Khởi tạo một QueryClient instance
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             // Dữ liệu sẽ được coi là "cũ" (stale) sau 5 phút.


### PR DESCRIPTION
- Integrated functionality to clear notification cache and hide toast messages before user logout in both SettingsScreen and axios response interceptor.
- Ensured a smoother user experience by preventing old notifications from displaying after logout.